### PR TITLE
give more resources to backend-lint job

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/kube-scheduler-simulator/kube-scheduler-simulator-presubmits-master.yaml
@@ -24,11 +24,11 @@ presubmits:
           make lint
         resources:
           limits:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 6Gi
           requests:
-            cpu: 2
-            memory: 4Gi
+            cpu: 4
+            memory: 6Gi
   - name: pull-kube-scheduler-simulator-frontend-lint
     cluster: eks-prow-build-cluster
     annotations:


### PR DESCRIPTION
After https://github.com/kubernetes/test-infra/pull/30183, we observed many Killed and the time gets 2x longer than before.
https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kube-scheduler-simulator-backend-lint